### PR TITLE
add appdirs to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+appdirs==1.4.4
 astroid==2.3.3
 cffi==1.14.0
 docopt==0.6.2


### PR DESCRIPTION
Just adding a dependency here.

PS, to your question about whether we need the `sleep` function in `main.js` -- I originally used that as a way of allowing the javascript process to restart the python process in Radiam, as it was the easiest way to stop the python crawler and reload the config without killing the tray app. We don't need to do that here, but I also used it to implement running tests from the js process, since we need some way of waiting for the Python process to spawn before attempting to send function calls to it when automating it, so I'd keep it for that.